### PR TITLE
Accept command line options and pass them through.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ The Current Scalafmt version is 0.6.5
 
 ## Usage
 
-Add the following snippet to your pom.
+Add the following snippet to your pom; anything in <parameters> will be
+passed through to the CLI as is.
 
 ```xml
 <plugin>
@@ -13,6 +14,7 @@ Add the following snippet to your pom.
   <artifactId>mvn-scalafmt</artifactId>
   <version>0.1</version>
   <configuration>
+    <parameters>--diff</parameters>
     <configLocation>${project.basedir}/path/to/scalafmt.conf</configLocation>
   </configuration>
   <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.antipathy</groupId>
     <artifactId>mvn-scalafmt</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>0.1</version>
+    <version>0.2</version>
     <name>Scalafmt Maven Plugin</name>
     <description>Maven plugin for ScalaFmt</description>
     <url>https://github.com/SimonJPegg/mvn_scalafmt</url>
@@ -24,6 +24,12 @@
             <organization>Antipathy.org</organization>
             <organizationUrl>http://www.antipathy.org</organizationUrl>
         </developer>
+        <developer>
+            <name>Eric Casteleijn</name>
+            <email>mumpsimus@simple.com</email>
+            <organization>simple.com</organization>
+            <organizationUrl>http://simple.com</organizationUrl>
+        </developer>
     </developers>
 
     <scm>
@@ -37,7 +43,7 @@
         <maven.annotations.version>3.4</maven.annotations.version>
         <scala.version>2.11.2</scala.version>
         <scala.major.version>2.11</scala.major.version>
-        <scalafmt.version>0.6.5</scalafmt.version>
+        <scalafmt.version>0.6.8</scalafmt.version>
         <commonslang.verson>2.6</commonslang.verson>
         <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
         <maven-compiler-plugin.version>2.0.2</maven-compiler-plugin.version>

--- a/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
+++ b/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
@@ -14,14 +14,16 @@ public class FormatMojo extends AbstractMojo {
 
     @Parameter(property="format.configLocation",defaultValue="")
     private String configLocation;
+    @Parameter(property="format.parameters",defaultValue="")
+    private String parameters;
 
     public void execute() throws MojoExecutionException {
         if(StringUtils.isEmpty(configLocation)) {
             throw new MojoExecutionException("No configuration file specified");
         } else {
-            getLog().info("Formatting with config: " + configLocation);
+            getLog().info("Formatting with config: " + configLocation + " and options: " + parameters);
             try {
-                Formatter.format(configLocation);
+                Formatter.format(configLocation, parameters);
             } catch (Exception e) {
                 throw new MojoExecutionException("Error formatting Scala files", e);
             }

--- a/src/main/scala/org/antipathy/scalafmtmvn/Formatter.scala
+++ b/src/main/scala/org/antipathy/scalafmtmvn/Formatter.scala
@@ -3,6 +3,9 @@ package org.antipathy.scalafmtmvn
 import org.scalafmt.Error.UnableToParseCliOptions
 import org.scalafmt.cli.{ Cli, CliOptions }
 
+import java.util.Arrays;
+import java.util.ArrayList;
+
 /**
  * Gets calls scalafmt with the config file specified at configLocation
  */
@@ -12,11 +15,13 @@ object Formatter {
    * Gets calls scalafmt with the config file specified at configLocation
    * @param configLocation the location of a scalafmt.conf file
    */
-  def format(configLocation: String): Unit =
-    Cli.getConfig(Array[String]("--config", configLocation), CliOptions.default) match {
+  def format(configLocation: String, parameters: String): Unit = {
+    val params = parameters.split(" ") ++ Seq("--config", configLocation)
+    Cli.getConfig(params.toArray, CliOptions.default) match {
       case Some(x) => Cli.run(x)
       case None =>
         throw new IllegalArgumentException(s"unable to parse config: $configLocation",
                                            UnableToParseCliOptions)
     }
+  }
 }

--- a/src/test/scala/org/antipathy/scalafmtmvn/FormatterSpec.scala
+++ b/src/test/scala/org/antipathy/scalafmtmvn/FormatterSpec.scala
@@ -11,7 +11,7 @@ class FormatterSpec extends FlatSpec with GivenWhenThen with Matchers {
 
   it should "raise an exception when unable to parse config file" in {
     an[IllegalArgumentException] should be thrownBy {
-      Formatter.format("/some/invalid/path")
+      Formatter.format("/some/invalid/path", "")
     }
   }
 }


### PR DESCRIPTION
Some command line options (like `--diff` and `--diff-branch` cannot be
specified in the scalafmt configuration file. This makes a change so
they can be passed in from the pom.xml as follows:

```xml
<plugin>
  <groupId>org.antipathy</groupId>
  <artifactId>mvn-scalafmt</artifactId>
  <version>0.1</version>
  <configuration>
    <parameters>--diff-branch some-branch</paramaters>
    <configLocation>${project.basedir}/path/to/scalafmt.conf</configLocation>
  </configuration>
  ...
</plugin>
```