### PR TITLE
Add versioning of scalafmt to pom snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ In the dependency section you can specify a scalafmt version.
     <dependency>
         <groupId>com.geirsson</groupId>
         <artifactId>scalafmt-cli_2.11</artifactId>
-        <version>0.6.8</version>
+        <version>0.6.8</version> <!-- or use a variable such as ${scalaFMTVersion}
+        to define the version in the properties section of the pom -->
     </dependency>
 </dependencies>
 </plugin>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In the dependency section you can specify a scalafmt version.
         <groupId>com.geirsson</groupId>
         <artifactId>scalafmt-core_2.11</artifactId>
         <version>0.6.8</version> <!-- or use a variable such as ${scalaFMTVersion}
-        to define the version in the properties section your pom -->
+        to define the version in the properties section of the pom -->
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.geirsson/scalafmt-cli_2.11 -->
     <dependency>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The Current Scalafmt version is 0.6.8
 Add the following snippet to your pom; anything in <parameters> will be
 passed through to the CLI as is.
 
+In the dependency section you can specify a scalafmt version.
+
 ```xml
 <plugin>
   <groupId>org.antipathy</groupId>
@@ -25,5 +27,20 @@ passed through to the CLI as is.
       </goals>
     </execution>
   </executions>
+  <dependencies>
+    <!-- https://mvnrepository.com/artifact/com.geirsson/scalafmt-core_2.11 -->
+    <dependency>
+        <groupId>com.geirsson</groupId>
+        <artifactId>scalafmt-core_2.11</artifactId>
+        <version>0.6.8</version> <!-- or use a variable such as ${scalaFMTVersion}
+        to define the version in the properties section your pom -->
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.geirsson/scalafmt-cli_2.11 -->
+    <dependency>
+        <groupId>com.geirsson</groupId>
+        <artifactId>scalafmt-cli_2.11</artifactId>
+        <version>0.6.8</version>
+    </dependency>
+</dependencies>
 </plugin>
 ```


### PR DESCRIPTION
Hi there. We use this plugin in our project as well and added a ${scalaFMTVersion} variable in the properties section of our pom. Choosing a particular version of scalaFMT may be beneficial for other users as well, since formatting can change between versions.
Thanks for the plugin!