### PR TITLE
Set aggregator in Mojo to execute once in multi-module

### DIFF
--- a/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
+++ b/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Get the location of the config file and pass to Formatter
  */
-@Mojo(name = "format")
+@Mojo(name = "format", aggregator = true)
 public class FormatMojo extends AbstractMojo {
 
     @Parameter(property = "format.configLocation")


### PR DESCRIPTION
When executing the plugin in a multi-module project the plugin is called once for each project, leading to problems in configuration and repetitions.