### PR TITLE
Enable skip of formatting for test/non test sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ Make sure your source paths are setup correctly, for example:
     ...
 </build>
 ```
+
+## Optional parameters
+
+| Name  | Default value | Description |
+| ------------- | ------------- | ------------- | 
+| skip  | false  | skip the execution of this plugin |
+| skipSources | false | the formatter skips the non test sources |
+| skipTestSources | false | the formatter skips the test sources |

--- a/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
+++ b/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
@@ -28,6 +28,10 @@ public class FormatMojo extends AbstractMojo {
     private boolean skip;
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
+    @Parameter(defaultValue = "false", required = true, readonly = true)
+    private boolean skipTestSources;
+    @Parameter(defaultValue = "false", required = true, readonly = true)
+    private boolean skipSources;
 
     public void execute() throws MojoExecutionException {
         if (skip) {
@@ -64,11 +68,11 @@ public class FormatMojo extends AbstractMojo {
 
     private String[] getSourceRoots() {
         List<String> sourceRoots = new ArrayList<>();
-        if (project.getCompileSourceRoots() != null) {
+        if (project.getCompileSourceRoots() != null && !skipSources) {
             //noinspection unchecked
             sourceRoots.addAll(project.getCompileSourceRoots());
         }
-        if (project.getTestCompileSourceRoots() != null) {
+        if (project.getTestCompileSourceRoots() != null && !skipTestSources) {
             //noinspection unchecked
             sourceRoots.addAll(project.getTestCompileSourceRoots());
         }

--- a/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
+++ b/src/main/java/org/antipathy/scalafmtmvn/FormatMojo.java
@@ -28,9 +28,9 @@ public class FormatMojo extends AbstractMojo {
     private boolean skip;
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
-    @Parameter(defaultValue = "false", required = true, readonly = true)
+    @Parameter(defaultValue = "false", readonly = true)
     private boolean skipTestSources;
-    @Parameter(defaultValue = "false", required = true, readonly = true)
+    @Parameter(defaultValue = "false", readonly = true)
     private boolean skipSources;
 
     public void execute() throws MojoExecutionException {


### PR DESCRIPTION
The idea is to avoid formatting twice the sources when we run 'mvn test' for example.

Let's say I want to format sources and test sources then I will bind the plugin to the process-sources and process-test-sources. The trouble is (non test) sources will be formatted twice