### PR TITLE
Use /scala as source directory by default as scala-maven-plugin does

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ passed through to the CLI as is.
     <skipmain>false</skipmain> <!-- (Optional) Skip formatting main sources -->
     <configLocation>${project.basedir}/path/to/scalafmt.conf</configLocation> <!-- (Optional) config location -->
     <configRequired>false</configRequired><!-- (Optional) raise an error if configLocation is missing or invalid (otherwise use Scalafmt defaults) -->
-    <sourceDirectories> <!-- (Optional) Paths to source-directories. Overrides ${project.build.sourceDirectory} -->
+    <sourceDirectories> <!-- (Optional) Paths to source-directories. Overrides ${project.build.sourceDirectory}/../scala -->
       <param>${project.basedir}/src/main/scala</param>
     </sourceDirectories>
-    <testSourceDirectories> <!-- (Optional) Paths to test-source-directories. Overrides ${project.build.testSourceDirectory} -->
+    <testSourceDirectories> <!-- (Optional) Paths to test-source-directories. Overrides ${project.build.testSourceDirectory}/../scala -->
       <param>${project.basedir}/src/test/scala</param>
     </testSourceDirectories>
   </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.antipathy</groupId>
     <artifactId>mvn-scalafmt_${version.scala.binary}</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>0.11_${version.scalafmt}</version>
+    <version>0.12_${version.scalafmt}</version>
     <name>ScalaFmt Maven Plugin (${version.scala.binary})</name>
     <description>Maven plugin for ScalaFmt</description>
     <url>https://github.com/SimonJPegg/mvn_scalafmt</url>

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -34,18 +34,14 @@ public class FormatMojo extends AbstractMojo {
     private List<File> testSourceDirectories;
 
     public void execute() throws MojoExecutionException {
-
-        List<File> sources = prepareSources(skipSources, sourceDirectories);
-        List<File> testSources = prepareSources(skipTestSources, testSourceDirectories);
-
         if(!skip) {
             try {
                 ScalaFormatter.format(
                         configLocation,
                         configRequired,
                         parameters,
-                        sources,
-                        testSources,
+                        skipSources ? Collections.emptyList() : sourceDirectories,
+                        skipTestSources ? Collections.emptyList() : testSourceDirectories,
                         getLog());
             } catch (Exception e) {
                 throw new MojoExecutionException("Error formatting Scala files", e);
@@ -53,19 +49,5 @@ public class FormatMojo extends AbstractMojo {
         } else {
             getLog().info("Skip flag set, skipping formatting");
         }
-    }
-
-    private List<File> prepareSources(boolean skip, List<File> sources) throws MojoExecutionException {
-        ArrayList<File> prepared = new ArrayList<>();
-        if(!skip) {
-            for (File source : sources) {
-                try {
-                    prepared.add(source.getCanonicalFile());
-                } catch (IOException e) {
-                    throw new MojoExecutionException("Can't get canonical file for " + source.toString(), e);
-                }
-            }
-        }
-        return Collections.unmodifiableList(prepared);
     }
 }

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -35,8 +35,8 @@ public class FormatMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException {
 
-        List<Object> sources = prepareSources(skipSources, sourceDirectories);
-        List<Object> testSources = prepareSources(skipTestSources, testSourceDirectories);
+        List<File> sources = prepareSources(skipSources, sourceDirectories);
+        List<File> testSources = prepareSources(skipTestSources, testSourceDirectories);
 
         if(!skip) {
             try {
@@ -55,8 +55,8 @@ public class FormatMojo extends AbstractMojo {
         }
     }
 
-    private List<Object> prepareSources(boolean skip, List<File> sources) throws MojoExecutionException {
-        ArrayList<Object> prepared = new ArrayList<>();
+    private List<File> prepareSources(boolean skip, List<File> sources) throws MojoExecutionException {
+        ArrayList<File> prepared = new ArrayList<>();
         if(!skip) {
             for (File source : sources) {
                 try {

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -26,9 +26,9 @@ public class FormatMojo extends AbstractMojo {
     private boolean skipTestSources;
     @Parameter(property = "format.skipmain", defaultValue = "false")
     private boolean skipSources;
-    @Parameter(defaultValue = "${project.build.sourceDirectory}", required = true)
+    @Parameter(defaultValue = "${project.build.sourceDirectory}/../scala", required = true)
     private List<File> sourceDirectories;
-    @Parameter(defaultValue = "${project.build.testSourceDirectory}", required = true)
+    @Parameter(defaultValue = "${project.build.testSourceDirectory}/../scala", required = true)
     private List<File> testSourceDirectories;
 
     public void execute() throws MojoExecutionException {

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -5,8 +5,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -5,7 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,16 +35,8 @@ public class FormatMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException {
 
-        ArrayList<Object> sources = new ArrayList<>();
-        ArrayList<Object> testSources = new ArrayList<>();
-
-        if (!skipSources) {
-            sources.addAll(sourceDirectories);
-        }
-
-        if (!skipTestSources) {
-            testSources.addAll(testSourceDirectories);
-        }
+        List<Object> sources = prepareSources(skipSources, sourceDirectories);
+        List<Object> testSources = prepareSources(skipTestSources, testSourceDirectories);
 
         if(!skip) {
             try {
@@ -59,5 +53,19 @@ public class FormatMojo extends AbstractMojo {
         } else {
             getLog().info("Skip flag set, skipping formatting");
         }
+    }
+
+    private List<Object> prepareSources(boolean skip, List<File> sources) throws MojoExecutionException {
+        ArrayList<Object> prepared = new ArrayList<>();
+        if(!skip) {
+            for (File source : sources) {
+                try {
+                    prepared.add(source.getCanonicalFile());
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Can't get canonical file for " + source.toString(), e);
+                }
+            }
+        }
+        return Collections.unmodifiableList(prepared);
     }
 }

--- a/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
@@ -40,7 +40,6 @@ object ScalaFormatter {
 
     if (sources.nonEmpty) {
       val cliOptions = getCLiOptions(sources, config, params)
-      log.info(sources.toString())
       log.info(s"Formatting ${sources.mkString(",")}")
       Cli.run(cliOptions)
     } else {

--- a/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
@@ -4,6 +4,7 @@ import org.scalafmt.cli.{Cli, CliOptions}
 import org.apache.maven.plugin.logging.Log
 import org.scalafmt.util.AbsoluteFile
 import scala.collection.JavaConverters._
+import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util.{List => JList}
 
@@ -26,8 +27,8 @@ object ScalaFormatter {
       configLocation: String,
       configRequired: Boolean,
       parameters: String,
-      sourceRoots: JList[Any],
-      testSourceRoots: JList[Any],
+      sourceRoots: JList[File],
+      testSourceRoots: JList[File],
       log: Log
   ): Unit = {
 
@@ -72,7 +73,7 @@ object ScalaFormatter {
     * @param paths the paths to filter
     * @return a sequence of valid paths
     */
-  private[mvn_scalafmt] def getSourcePaths(paths: Seq[Any]): Seq[String] =
+  private[mvn_scalafmt] def getSourcePaths(paths: Seq[File]): Seq[String] =
     if (paths == null) {
       Seq[String]()
     } else {

--- a/src/test/scala/org/antipathy/mvn_scalafmt/ScalaFormatterSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/ScalaFormatterSpec.scala
@@ -62,15 +62,19 @@ class ScalaFormatterSpec extends FlatSpec with GivenWhenThen with Matchers {
   it should "Create a sequence of valid source paths" in {
     val sources = Seq(new File("src/main/scala"), new File("src/test/scala"))
     val expectedResult = Seq("src/main/scala", "src/test/scala")
-    ScalaFormatter.getSourcePaths(sources) should be(expectedResult)
+    canonical(ScalaFormatter.getSourcePaths(sources, new SystemStreamLog)) should be(canonical(expectedResult))
   }
 
   it should "Create an empty sequence when given invalid paths" in {
-    ScalaFormatter.getSourcePaths(Seq(new File("src/main1/scala"), new File("src/test1/scala"))) should be(Seq())
+    ScalaFormatter.getSourcePaths(Seq(new File("src/main1/scala"), new File("src/test1/scala")), new SystemStreamLog) should be(
+      Seq())
   }
 
   it should "Create an empty sequence when given null values" in {
-    ScalaFormatter.getSourcePaths(null) should be(Seq())
+    ScalaFormatter.getSourcePaths(null, new SystemStreamLog) should be(Seq())
   }
+
+  private def canonical(paths: Seq[String]) =
+    paths.map(new File(_).getCanonicalFile)
 
 }

--- a/src/test/scala/org/antipathy/mvn_scalafmt/ScalaFormatterSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/ScalaFormatterSpec.scala
@@ -1,5 +1,7 @@
 package org.antipathy.mvn_scalafmt
 
+import java.io.File
+
 import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
 import org.apache.maven.plugin.logging.SystemStreamLog
 
@@ -58,12 +60,13 @@ class ScalaFormatterSpec extends FlatSpec with GivenWhenThen with Matchers {
   }
 
   it should "Create a sequence of valid source paths" in {
+    val sources = Seq(new File("src/main/scala"), new File("src/test/scala"))
     val expectedResult = Seq("src/main/scala", "src/test/scala")
-    ScalaFormatter.getSourcePaths(expectedResult) should be(expectedResult)
+    ScalaFormatter.getSourcePaths(sources) should be(expectedResult)
   }
 
   it should "Create an empty sequence when given invalid paths" in {
-    ScalaFormatter.getSourcePaths(Seq("src/main1/scala", "src/test1/scala")) should be(Seq())
+    ScalaFormatter.getSourcePaths(Seq(new File("src/main1/scala"), new File("src/test1/scala"))) should be(Seq())
   }
 
   it should "Create an empty sequence when given null values" in {


### PR DESCRIPTION
Usually, we put Scala sources into /scala directory anyway, so it's sensible default.

With this patch we don't have to manually define `<build><sourceDirectory>src/main/scala</...></...>`.

Related links to scala-maven-plugin code:

https://github.com/davidB/scala-maven-plugin/blob/ae4e0caecf4040ba943d2d75aafd1975fa476a55/src/main/java/scala_maven/ScalaContinuousCompileMojo.java#L34

https://github.com/davidB/scala-maven-plugin/blob/ae4e0caecf4040ba943d2d75aafd1975fa476a55/src/main/java/scala_maven/ScalaContinuousCompileMojo.java#L133