### PR TITLE
Fail build if Scalafmt reports errors

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0-RC1"
+version = "2.0.1"
 style = defaultWithAlign
 maxColumn = 120
 continuationIndent.callSite = 2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.antipathy</groupId>
     <artifactId>mvn-scalafmt_${version.scala.major}</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>ScalaFmt Maven Plugin (${version.scala.major})</name>
     <description>Maven plugin for ScalaFmt</description>
     <url>https://github.com/SimonJPegg/mvn_scalafmt</url>
@@ -44,15 +44,15 @@
         <version.maven.plugin.nexus.staging>1.6.8</version.maven.plugin.nexus.staging>
         <version.maven.plugin.plugin>3.5.2</version.maven.plugin.plugin>
         <version.maven.plugin.scala>3.4.2</version.maven.plugin.scala>
-        <version.maven.plugin.scalatest>1.0</version.maven.plugin.scalatest>
+        <version.maven.plugin.scalatest>2.0.0</version.maven.plugin.scalatest>
         <version.maven.plugin.source>3.1.0</version.maven.plugin.source>
         <version.maven.plugin.surefire>2.7</version.maven.plugin.surefire>
         <version.maven>3.5.4</version.maven>
         <version.scala.major>2.12</version.scala.major>
-        <version.scala.minor>.8</version.scala.minor>
+        <version.scala.minor>.10</version.scala.minor>
         <version.scala.xml>1.2.0</version.scala.xml>
         <version.scalafmt.dynamic>2.0.1</version.scalafmt.dynamic>
-        <version.scalatest>3.0.5</version.scalatest>
+        <version.scalatest>3.0.8</version.scalatest>
 
         <maven.compiler.source>${version.java}</maven.compiler.source>
         <maven.compiler.target>${version.java}</maven.compiler.target>
@@ -176,12 +176,12 @@
             <plugin>
                 <groupId>org.antipathy</groupId>
                 <artifactId>mvn-scalafmt_${version.scala.major}</artifactId>
-                <version>1.0.0-RC2</version>
+                <version>1.0.1</version>
                 <configuration>
                     <configLocation>${project.basedir}/.scalafmt.conf</configLocation>
                     <skipTestSources>false</skipTestSources>
                     <skipSources>false</skipSources>
-                    <respectVersion>false</respectVersion>
+                    <respectVersion>true</respectVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/scala/org/antipathy/mvn_scalafmt/logging/MavenLogReporter.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/logging/MavenLogReporter.scala
@@ -4,8 +4,8 @@ import java.io.PrintWriter
 import java.nio.file.Path
 
 import org.apache.maven.plugin.logging.Log
-import org.scalafmt.interfaces.ScalafmtReporter
 import org.scalafmt.dynamic.exceptions.ScalafmtException
+import org.scalafmt.interfaces.ScalafmtReporter
 
 /**
   * Class for logging Scalafmt events via the maven log
@@ -13,17 +13,17 @@ import org.scalafmt.dynamic.exceptions.ScalafmtException
   */
 class MavenLogReporter(log: Log) extends ScalafmtReporter {
 
-
-
   /**
     * log errors
     */
-  override def error(path: Path, message: String): Unit = log.error(s"ScalaFmt: error: $path: $message")
+  override def error(path: Path, message: String): Unit =
+    throw new ScalafmtException(message, null)
 
   /**
     * log errors with exceptions
     */
-  override def error(file: Path, e: Throwable): Unit = error(file, ScalafmtException(e.getMessage, e))
+  override def error(file: Path, e: Throwable): Unit =
+    throw e
 
   /**
     * log excluded files

--- a/src/test/scala/org/antipathy/mvn_scalafmt/logging/MavenLogReporterSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/logging/MavenLogReporterSpec.scala
@@ -1,0 +1,37 @@
+package org.antipathy.mvn_scalafmt.logging
+
+import java.io.File
+
+import org.apache.maven.monitor.logging.DefaultLog
+import org.codehaus.plexus.logging.console.ConsoleLogger
+import org.scalafmt.dynamic.exceptions.ScalafmtException
+import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
+
+class MavenLogReporterSpec extends FlatSpec with GivenWhenThen with Matchers {
+
+  val reporter = new MavenLogReporter(new DefaultLog(new ConsoleLogger()))
+
+  behavior of "MavenLogReporter"
+
+  it should "throw an error if error is reported by Scalafmt" in {
+
+    val ex1 = intercept[ScalafmtException] {
+      reporter.error(new File("").toPath, "Oops")
+    }
+
+    ex1.getMessage shouldEqual "Oops"
+
+    val ex2 = intercept[RuntimeException] {
+      reporter.error(new File("").toPath, "No way!", new RuntimeException("Oops"))
+    }
+
+    ex2.getMessage shouldEqual "No way!"
+
+    val ex3 = intercept[RuntimeException] {
+      reporter.error(new File("").toPath, new RuntimeException("Oops"))
+    }
+
+    ex3.getMessage shouldEqual "Oops"
+  }
+
+}


### PR DESCRIPTION
# Description
This is related to #42 . Currently scalafmt-dynamic reports errors to reporter, but doesn't indicate the error otherwise, so mvn_scalafmt may log tons of errors and then successfully finishes the build.
here's example

```shell
➜  mvn_scalafmt git:(fail-on-errors) ✗ mvn org.antipathy:mvn-scalafmt_2.12:format
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.antipathy:mvn-scalafmt_2.12:maven-plugin:1.0.2-SNAPSHOT
[WARNING] 'artifactId' contains an expression but should be a constant. @ org.antipathy:mvn-scalafmt_${version.scala.major}:1.0.2-SNAPSHOT, /home/jozic/projects/github/mvn_scalafmt/pom.xml, line 5, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------< org.antipathy:mvn-scalafmt_2.12 >-------------------
[INFO] Building ScalaFmt Maven Plugin (2.12) 1.0.2-SNAPSHOT
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- mvn-scalafmt_2.12:1.0.0:format (default-cli) @ mvn-scalafmt_2.12 ---
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[ERROR] ScalaFmt: error: /home/jozic/projects/github/mvn_scalafmt/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[INFO] Scalafmt results: 0 of 28 were unformatted
Details:
ConfigFileValidator.scala: Correctly formatted: 
Validator.scala: Correctly formatted: 
ScalaFormatter.scala: Correctly formatted: 
SourceFileSequenceBuilder.scala: Correctly formatted: 
Builder.scala: Correctly formatted: 
LocalConfigBuilder.scala: Correctly formatted: 
FilesSummaryBuilder.scala: Correctly formatted: 
Formatter.scala: Correctly formatted: 
SourceFileFormatter.scala: Correctly formatted: 
RemoteConfigWriter.scala: Correctly formatted: 
TestResultLogWriter.scala: Correctly formatted: 
Reader.scala: Correctly formatted: 
RemoteConfigReader.scala: Correctly formatted: 
Writer.scala: Correctly formatted: 
FormattedFilesWriter.scala: Correctly formatted: 
Summary.scala: Correctly formatted: 
FileSummaryRequest.scala: Correctly formatted: 
FileSummary.scala: Correctly formatted: 
RemoteConfig.scala: Correctly formatted: 
FormatResult.scala: Correctly formatted: 
MavenLogReporter.scala: Correctly formatted: 
ConfigFileValidatorSpec.scala: Correctly formatted: 
SourceFileSequenceBuilderSpec.scala: Correctly formatted: 
LocalConfigBuilderSpec.scala: Correctly formatted: 
SourceFileFormatterSpec.scala: Correctly formatted: 
FormattedFilesWriterSpec.scala: Correctly formatted: 
RemoteConfigReaderSpec.scala: Correctly formatted: 
RemoteConfigWriterSpec.scala: Correctly formatted: 
     
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.172 s
[INFO] Finished at: 2019-09-30T07:25:46-04:00
[INFO] ------------------------------------------------------------------------
```

with this fix, it's gonna be like

```shell
➜  mvn_scalafmt git:(fail-on-errors) ✗ mvn org.antipathy:mvn-scalafmt_2.12:format
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.antipathy:mvn-scalafmt_2.12:maven-plugin:1.0.2-SNAPSHOT
[WARNING] 'artifactId' contains an expression but should be a constant. @ org.antipathy:mvn-scalafmt_${version.scala.major}:1.0.2-SNAPSHOT, /home/jozic/projects/github/mvn_scalafmt/pom.xml, line 5, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------< org.antipathy:mvn-scalafmt_2.12 >-------------------
[INFO] Building ScalaFmt Maven Plugin (2.12) 1.0.2-SNAPSHOT
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- mvn-scalafmt_2.12:1.0.2-SNAPSHOT:format (default-cli) @ mvn-scalafmt_2.12 ---
[ERROR] 
org.scalafmt.dynamic.exceptions.ScalafmtException: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.871 s
[INFO] Finished at: 2019-10-13T21:23:17-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.antipathy:mvn-scalafmt_2.12:1.0.2-SNAPSHOT:format (default-cli) on project mvn-scalafmt_2.12: Error formatting Scala files: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

I can add some scalatests if this solution looks acceptable


Fixes # (issue)
#42 
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually
### To Reproduce
0. Checkout this project, master branch
1. Make `.scalafmt.conf` invalid in some way (e.g.add a space inside of one of the rule names)
2. Run `mvn org.antipathy:mvn-scalafmt_2.12:format`
3. Observe errors in logs and successful build message at the end

### To Test the Fix
0. Checkout this project, fix branch
1. mvn clean install
1. Make `.scalafmt.conf` invalid in some way (e.g.add a space inside of one of the rule names)
2. Change version to the the one just installed (1.0.2-SNAPSHOT)
2. Run `mvn org.antipathy:mvn-scalafmt_2.12:format`
3. Observe errors in logs and error build message at the end
 
**Test Configuration**:
* Firmware version: Linux Mint 18.1
* SDK: 
```java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)
```

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
