### PR TITLE
Fix onlyChangedFiles in mvn module with git root directory  != project.basedir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+.flattened-pom.xml
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dversion.scala.major=2.13 -Dversion.scala.minor=.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,18 @@ jdk:
   - openjdk8
   - openjdk11
 
+env:
+  - SCALA_MAJOR=2.13 SCALA_MINOR=.1
+  - SCALA_MAJOR=2.12 SCALA_MINOR=.10
+  - SCALA_MAJOR=2.11 SCALA_MINOR=.12
+
 before_install:
   - wget http://apache.mirror.gtcomm.net/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
   - tar xzvf apache-maven-3.6.3-bin.tar.gz
   - export PATH=`pwd`/apache-maven-3.6.3/bin:$PATH
 
 install:
-  mvn --settings .maven.xml clean test -B -V
+  mvn --settings .maven.xml clean test -B -V -Dversion.scala.major=$SCALA_MAJOR -Dversion.scala.minor=$SCALA_MINOR
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 
 jdk:
   - openjdk8
+  - openjdk11
 
 before_install:
   - wget http://apache.mirror.gtcomm.net/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Note: `version.scala.binary` refers to major releases of scala ie. 2.11, 2.12 or
         </testSourceDirectories>
         <validateOnly>false</validateOnly> <!-- check formatting without changing files -->
         <onlyChangedFiles>true</onlyChangedFiles> <!-- only format (staged) files that have been changed from the specified git branch -->
-        <branch>master</branch> <!-- The git branch to check against -->
+        <!-- The git branch to check against
+             If branch.startsWith(": ") the value in <branch> tag is used as a command to run
+             and the output will be used as the actual branch-->
+        <branch>: git rev-parse --abbrev-ref HEAD</branch> <!-- the current branch-->
+        <!-- <branch>master</branch>-->
     </configuration>
     <executions>
         <execution>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Note: `version.scala.binary` refers to major releases of scala ie. 2.11, 2.12 or
 ```xml
 <plugin>
     <groupId>org.antipathy</groupId>
-    <artifactId>mvn-scalafmt_${version.scala.binary}</artifactId>
+    <!-- Always use mvn-scalafmt_2.13.
+         We don't need to use the same scala version setting as in the maven ${project} -->
+    <artifactId>mvn-scalafmt_2.13</artifactId>
+    <!-- <artifactId>mvn-scalafmt_${version.scala.binary}</artifactId> -->
     <version>1.0.3</version>
     <configuration>
         <configLocation>${project.basedir}/.scalafmt.conf</configLocation> <!-- path to config -->

--- a/pom.xml
+++ b/pom.xml
@@ -182,8 +182,10 @@
             </plugin>
             <plugin>
                 <groupId>org.antipathy</groupId>
-                <artifactId>mvn-scalafmt_${version.scala.major}</artifactId>
-                <version>1.0.2</version>
+                <!-- Always use mvn-scalafmt_2.13.
+                     We don't need to use the same scala version setting as in the maven ${project} -->
+                <artifactId>mvn-scalafmt_2.13</artifactId>
+                <version>1.0.3</version>
                 <configuration>
                     <configLocation>${project.basedir}/.scalafmt.conf</configLocation>
                     <skipTestSources>false</skipTestSources>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <version.maven.plugin.javadoc>3.1.0</version.maven.plugin.javadoc>
         <version.maven.plugin.nexus.staging>1.6.8</version.maven.plugin.nexus.staging>
         <version.maven.plugin.plugin>3.5.2</version.maven.plugin.plugin>
-        <version.maven.plugin.scala>3.4.2</version.maven.plugin.scala>
+        <version.maven.plugin.scala>4.3.1</version.maven.plugin.scala>
         <version.maven.plugin.scalatest>2.0.0</version.maven.plugin.scalatest>
         <version.maven.plugin.source>3.1.0</version.maven.plugin.source>
         <version.maven.plugin.surefire>2.7</version.maven.plugin.surefire>
@@ -52,7 +52,7 @@
         <version.scala.minor>.1</version.scala.minor>
         <version.scala.xml>1.2.0</version.scala.xml>
         <version.scalafmt.dynamic>2.3.2</version.scalafmt.dynamic>
-        <version.scalatest>3.0.8</version.scalatest>
+        <version.scalatest>3.1.0</version.scalatest>
 
         <maven.compiler.source>${version.java}</maven.compiler.source>
         <maven.compiler.target>${version.java}</maven.compiler.target>
@@ -150,6 +150,13 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <args>
+                        <arg>-target:jvm-1.8</arg>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                    </args>
+                </configuration>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <configuration>
+                    <flattenMode>oss</flattenMode>
+                    <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,6 @@
         <version.maven.plugin.source>3.1.0</version.maven.plugin.source>
         <version.maven.plugin.surefire>2.7</version.maven.plugin.surefire>
         <version.maven>3.5.4</version.maven>
-        <version.scala.major>2.13</version.scala.major>
-        <version.scala.minor>.1</version.scala.minor>
         <version.scala.xml>1.2.0</version.scala.xml>
         <version.scalafmt.dynamic>2.3.2</version.scalafmt.dynamic>
         <version.scalatest>3.1.0</version.scalatest>
@@ -282,4 +280,22 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>scala_NOT_2.13</id>
+            <activation>
+                <property>
+                    <name>version.scala.major</name>
+                    <value>!2.13</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-collection-compat_${version.scala.major}</artifactId>
+                    <version>2.1.3</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -33,6 +33,12 @@ public class FormatMojo extends AbstractMojo {
     private boolean validateOnly;
     @Parameter(property = "format.onlyChangedFiles", defaultValue = "false")
     private boolean onlyChangedFiles;
+    /** if branch.startsWith(": "), ex set in pom.xml:
+      * <pre>{@code
+      * <!-- the current branch-->
+      * <branch>: git rev-parse --abbrev-ref HEAD</branch>
+      * }</pre>
+      * then we consider the value in {@code <branch>} tag as a command to run and the output will be used as the actual branch */
     @Parameter(property = "format.branch", defaultValue = "master")
     private String branch;
     @Parameter(readonly = true, defaultValue = "${project}")

--- a/src/main/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilder.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilder.scala
@@ -54,10 +54,10 @@ object ChangedFilesBuilder {
 
     def run(cmd: String) = Process(cmd, workingDirectory).!!(logger).trim
 
-    val actualBranch = branch match {
-      case s": $x" => run(x)
-      case x       => x
-    }
+    val prefix = ": "
+    val actualBranch =
+      if (!branch.startsWith(prefix)) branch
+      else run(branch.substring(prefix.length))
 
     def processFunction(): Seq[File] = {
       val diffOutput    = run(s"git diff --name-only --diff-filter=d $actualBranch")

--- a/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala
@@ -19,7 +19,7 @@ class ChangedFilesBuilderSpec extends FlatSpec with GivenWhenThen with Matchers 
       "/mvn_scalafmt/src/test/scala/org/antipathy/mvn_scalafmt/builder/LocalConfigBuilderSpec.scala"
     )
 
-    val changeFunction = () => changedFiles.mkString(System.lineSeparator())
+    val changeFunction = () => changedFiles.map(new File(_))
 
     val result = new ChangedFilesBuilder(log, true, "master", changeFunction).build(sources)
     result should be(changedFiles.map(new File(_)))


### PR DESCRIPTION
# Description

+ When mvn_scalafmt 1.0.3 is used in a maven module with git root directory  != `project.basedir`,
   for example git root directory `== /couchbase-jvm-clients`, and `project.basedir == /couchbase-jvm-clients/scala-client`
   then `ChangedFilesBuilder.build` return incorrect files, ex:
   `/couchbase-jvm-clients/scala-client/scala-client/src/main/scala/`<a .scala file>
   (note the duplicated `scala-client` in the path)

+ Document: Clearify that users can safely always use mvn-scalafmt_2.13
+ Permit using a shell command to extract the branch name.
   See changes in README.md for more details.

+ Update scala-maven-plugin 4.3.1 & scalatest 3.1.0

+ Add openjdk11 & scala 2.12.10, 2.11.12 to travis matrix

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
```
mvn help:active-profiles
mvn help:active-profiles -Dversion.scala.major=2.12 -Dversion.scala.minor=.10
mvn clean test
mvn clean test -Dversion.scala.major=2.12 -Dversion.scala.minor=.10
mvn clean test -Dversion.scala.major=2.11 -Dversion.scala.minor=.12
```

**Test Configuration**:
* Hardware: osx
* SDK: openjdk8, openjdk11

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules