### PR TITLE
Windows OS compatible unit tests  + Independent file reading from EOL…

### DIFF
--- a/src/main/scala/org/antipathy/mvn_scalafmt/format/SourceFileFormatter.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/format/SourceFileFormatter.scala
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import org.antipathy.mvn_scalafmt.model.FormatResult
 import org.apache.maven.plugin.logging.Log
 import org.scalafmt.interfaces.Scalafmt
+import java.nio.file.Files
 
 /**
   * Class for formatting source files
@@ -26,7 +27,7 @@ class SourceFileFormatter(
     */
   override def format(sourceFile: File): FormatResult = {
     log.debug(s"Parsing file: ${sourceFile.getCanonicalPath}")
-    val unformattedSource = scala.io.Source.fromFile(sourceFile).getLines().mkString(System.lineSeparator())
+    val unformattedSource = new String(Files.readAllBytes(sourceFile.toPath))
     FormatResult(sourceFile, unformattedSource, inner.format(config, sourceFile.toPath, unformattedSource))
   }
 }

--- a/src/main/scala/org/antipathy/mvn_scalafmt/model/Summary.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/model/Summary.scala
@@ -15,6 +15,6 @@ case class Summary(
   override def toString: String =
     s"""Scalafmt results: $unformattedFiles of $totalFiles were unformatted
        |Details:
-       |${fileDetails.mkString("\n")}
+       |${fileDetails.mkString(System.lineSeparator)}
      """.stripMargin
 }

--- a/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala
@@ -2,6 +2,7 @@ package org.antipathy.mvn_scalafmt.builder
 
 import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
 import java.io.File
+import java.nio.file.Paths
 
 import org.apache.maven.plugin.logging.SystemStreamLog
 
@@ -27,5 +28,5 @@ class ChangedFilesBuilderSpec extends FlatSpec with GivenWhenThen with Matchers 
   }
 
   def getAbsolutePathFrom(path: String): String =
-    new File(path).getAbsolutePath
+    Paths.get(path).normalize.toAbsolutePath.toString
 }

--- a/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala
@@ -2,6 +2,7 @@ package org.antipathy.mvn_scalafmt.builder
 
 import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
 import java.io.File
+
 import org.apache.maven.plugin.logging.SystemStreamLog
 
 class ChangedFilesBuilderSpec extends FlatSpec with GivenWhenThen with Matchers {
@@ -17,11 +18,14 @@ class ChangedFilesBuilderSpec extends FlatSpec with GivenWhenThen with Matchers 
       "/mvn_scalafmt/src/main/scala/org/antipathy/mvn_scalafmt/builder/SourceFileSequenceBuilder.scala",
       "/mvn_scalafmt/src/test/scala/org/antipathy/mvn_scalafmt/builder/ChangedFilesBuilderSpec.scala",
       "/mvn_scalafmt/src/test/scala/org/antipathy/mvn_scalafmt/builder/LocalConfigBuilderSpec.scala"
-    )
+    ).map(x => getAbsolutePathFrom(x))
 
     val changeFunction = () => changedFiles.mkString(System.lineSeparator())
 
     val result = new ChangedFilesBuilder(log, true, "master", changeFunction).build(sources)
     result should be(changedFiles.map(new File(_)))
   }
+
+  def getAbsolutePathFrom(path: String): String =
+    new File(path).getAbsolutePath
 }

--- a/src/test/scala/org/antipathy/mvn_scalafmt/builder/LocalConfigBuilderSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/builder/LocalConfigBuilderSpec.scala
@@ -3,6 +3,7 @@ package org.antipathy.mvn_scalafmt.builder
 import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
 import org.apache.maven.plugin.logging.SystemStreamLog
 import java.io.File
+import java.nio.file.Files
 
 class LocalConfigBuilderSpec extends FlatSpec with GivenWhenThen with Matchers {
 
@@ -28,9 +29,7 @@ class LocalConfigBuilderSpec extends FlatSpec with GivenWhenThen with Matchers {
 
     builder.build(path)
 
-    val source = scala.io.Source.fromFile(new File(".scalafmt.conf"))
-    val result = source.getLines().mkString(System.lineSeparator())
-    source.close()
+    val result = new String(Files.readAllBytes(new File(".scalafmt.conf").toPath))
     result.trim should be(expectedContent.trim)
   }
 

--- a/src/test/scala/org/antipathy/mvn_scalafmt/format/SourceFileFormatterSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/format/SourceFileFormatterSpec.scala
@@ -1,6 +1,7 @@
 package org.antipathy.mvn_scalafmt.format
 
 import java.io.File
+import java.nio.file.Files
 
 import org.antipathy.mvn_scalafmt.logging.MavenLogReporter
 import org.antipathy.mvn_scalafmt.validation.ConfigFileValidator
@@ -23,6 +24,6 @@ class SourceFileFormatterSpec extends FlatSpec with GivenWhenThen with Matchers 
 
     val result = new SourceFileFormatter(config, scalafmt, log).format(sourceFile).formattedSource
 
-    result.trim should be(scala.io.Source.fromFile(sourceFile).getLines().mkString(System.lineSeparator()).trim)
+    result.trim should be(new String(Files.readAllBytes(sourceFile.toPath)).trim)
   }
 }

--- a/src/test/scala/org/antipathy/mvn_scalafmt/io/FormattedFilesWriterSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/io/FormattedFilesWriterSpec.scala
@@ -2,6 +2,7 @@ package org.antipathy.mvn_scalafmt.io
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import org.antipathy.mvn_scalafmt.model.FormatResult
 import org.apache.commons.io.FileUtils
@@ -21,11 +22,11 @@ class FormattedFilesWriterSpec extends FlatSpec with GivenWhenThen with Matchers
     val formatResult = FormatResult(sourceFile, originalContent, changedContent)
     val fileWriter   = new FormattedFilesWriter(new SystemStreamLog)
 
-    scala.io.Source.fromFile(sourceFile).getLines().mkString should be(originalContent)
+    new String(Files.readAllBytes(sourceFile.toPath)) should be(originalContent)
 
     fileWriter.write(Seq(formatResult))
 
-    scala.io.Source.fromFile(sourceFile).getLines().mkString should be(changedContent)
+    new String(Files.readAllBytes(sourceFile.toPath)) should be(changedContent)
 
     sourceFile.delete()
   }

--- a/src/test/scala/org/antipathy/mvn_scalafmt/io/RemoteConfigWriterSpec.scala
+++ b/src/test/scala/org/antipathy/mvn_scalafmt/io/RemoteConfigWriterSpec.scala
@@ -29,7 +29,7 @@ class RemoteConfigWriterSpec extends FlatSpec with GivenWhenThen with Matchers {
 
     writer.write(input)
 
-    scala.io.Source.fromFile(new File(localPath)).mkString should be(contents)
+    new String(Files.readAllBytes(new File(localPath).toPath))
     Files.delete(input.location)
   }
 
@@ -51,11 +51,11 @@ class RemoteConfigWriterSpec extends FlatSpec with GivenWhenThen with Matchers {
     val input  = RemoteConfig(contents, Paths.get(localPath))
 
     FileUtils.writeStringToFile(new File(localPath), oldContents, StandardCharsets.UTF_8)
-    scala.io.Source.fromFile(new File(localPath)).mkString should be(oldContents)
+    new String(Files.readAllBytes(new File(localPath).toPath)) should be(oldContents)
 
     writer.write(input)
 
-    scala.io.Source.fromFile(new File(localPath)).mkString should be(contents)
+    new String(Files.readAllBytes(new File(localPath).toPath)) should be(contents)
     Files.delete(input.location)
   }
 


### PR DESCRIPTION
# Description
This PR solves issues: 
* https://github.com/SimonJPegg/mvn_scalafmt/issues/52 - Reading as String using the same EOL as the original file.
* https://github.com/SimonJPegg/mvn_scalafmt/issues/53 - Unit tests failing in Windows

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Regarding EOL files, I ran my changes using unix-like EOL files in windows. With the changes in this PR, the files are not rewritten if no change was in them. If validateOnly=true, no error is thrown.

Regarding unit tests, they  were failing in my Windows machine. I just fixed them keeping compatibility with mac/linux

**Test Configuration**:
* Hardware: Win10 OS PC
* SDK: Java 1.8.0_241
* Maven 3.6.1

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
