### PR TITLE
Support using repositories project configuration for dynamic scalafmt loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Note: `version.scala.binary` refers to major releases of scala ie. 2.11, 2.12 or
         <validateOnly>false</validateOnly> <!-- check formatting without changing files -->
         <onlyChangedFiles>true</onlyChangedFiles> <!-- only format (staged) files that have been changed from the specified git branch -->
         <branch>master</branch> <!-- The git branch to check against -->
+        <useSpecifiedRepositories>false</useSpecifiedRepositories> <!-- use project repositories configuration for scalafmt dynamic loading -->
     </configuration>
     <executions>
         <execution>

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.model.Repository;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -37,11 +38,21 @@ public class FormatMojo extends AbstractMojo {
     private String branch;
     @Parameter(readonly = true, defaultValue = "${project}")
     private MavenProject project;
+    @Parameter(property = "format.use.specified.repositories", defaultValue = "false", required = false)
+    private boolean useSpecifiedRepositories;
+    @Parameter(property = "format.maven.repositories", defaultValue = "${project.repositories}", required = false)
+    private List<Repository> mavenRepositories;
 
 
     public void execute() throws MojoExecutionException {
 
         List<File> sources = new ArrayList<>();
+
+        List<String> mavenRepositoriesUrls = new ArrayList<>(mavenRepositories.size());
+
+        for (Repository r: mavenRepositories) {
+            mavenRepositoriesUrls.add(r.getUrl());
+        }
 
         if (!skipSources) {
             sources.addAll(sourceDirectories);
@@ -64,7 +75,9 @@ public class FormatMojo extends AbstractMojo {
                         validateOnly,
                         onlyChangedFiles,
                         branch,
-                        project.getBasedir()
+                        project.getBasedir(),
+                        useSpecifiedRepositories,
+                        mavenRepositoriesUrls
                 ).format(sources);
                 getLog().info(result.toString());
                 if (validateOnly && result.unformattedFiles() != 0) {

--- a/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
@@ -53,14 +53,14 @@ object ScalaFormatter {
     * @return a new ScalaFormatter instance
     */
   def apply(
-             configLocation: String,
-             log: Log,
-             respectVersion: Boolean,
-             testOnly: Boolean,
-             onlyChangedFiles: Boolean,
-             branch: String,
-             workingDirectory: File,
-             mavenRepositoryUrls: JList[String]
+    configLocation: String,
+    log: Log,
+    respectVersion: Boolean,
+    testOnly: Boolean,
+    onlyChangedFiles: Boolean,
+    branch: String,
+    workingDirectory: File,
+    mavenRepositoryUrls: JList[String]
   ): ScalaFormatter = {
     val config              = LocalConfigBuilder(log).build(configLocation)
     val sourceBuilder       = new SourceFileSequenceBuilder(log)

--- a/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/ScalaFormatter.scala
@@ -48,33 +48,29 @@ object ScalaFormatter {
     * @param onlyChangedFiles Should only changed files be formatted
     * @param branch The branch to compare against for changed files
     * @param workingDirectory The project working directory
+    * @param mavenRepositoryUrls The maven repositories to be used to dynamically load scalafmt, empty if maven central
+    *                            should be used.
     * @return a new ScalaFormatter instance
     */
   def apply(
-    configLocation: String,
-    log: Log,
-    respectVersion: Boolean,
-    testOnly: Boolean,
-    onlyChangedFiles: Boolean,
-    branch: String,
-    workingDirectory: File,
-    useSpecifiedRepositories: Boolean,
-    mavenRepositories: JList[String]
+             configLocation: String,
+             log: Log,
+             respectVersion: Boolean,
+             testOnly: Boolean,
+             onlyChangedFiles: Boolean,
+             branch: String,
+             workingDirectory: File,
+             mavenRepositoryUrls: JList[String]
   ): ScalaFormatter = {
     val config              = LocalConfigBuilder(log).build(configLocation)
     val sourceBuilder       = new SourceFileSequenceBuilder(log)
     val changedFilesBuilder = ChangedFilesBuilder(log, onlyChangedFiles, branch, workingDirectory)
 
-    val mvnReps = mavenRepositories.asScala
-
-    val scalafmtBuilder = Scalafmt
+    val scalafmt = Scalafmt
       .create(this.getClass.getClassLoader)
       .withReporter(new MavenLogReporter(log))
       .withRespectVersion(respectVersion)
-
-    val scalafmt =
-      if (useSpecifiedRepositories && mvnReps.nonEmpty) scalafmtBuilder.withMavenRepositories(mvnReps.toSeq: _*)
-      else scalafmtBuilder
+      .withMavenRepositories(mavenRepositoryUrls.asScala.toSeq: _*)
 
     val sourceFormatter = new SourceFileFormatter(config, scalafmt, log)
 


### PR DESCRIPTION
# Description

When working behind proxy the dynamic loading of the scalafmt will fail.
In some cases the organisation might have a mirror of maven central that can be used.
This PR enables the user to indicate the maven repositories to be by scalafmt dynamic loading.

Fixes # (issue)
https://github.com/SimonJPegg/mvn_scalafmt/issues/49

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have created a local instance of the plugin and run once behind proxy seeing it fails, when setting the new property to true the call was successful 