### PR TITLE
Set proposed "validate" as default phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A wrapper that allows the use of the [Scalafmt](https://github.com/scalameta/sca
 
 ## Usage
 
-Add the following snippet to your pom.
+Add the following snippet to your pom, and it will be invoked as part of your build during the
+selected lifecycle phase (default `validate`).
 
 Note: `version.scala.binary` refers to major releases of scala ie. 2.11, 2.12 or 2.13.  
 mvn_scalafmt_2.11 will soon be deprecated and may not receive future releases
@@ -83,7 +84,7 @@ The latest release should be visible at the top of this readme.
     </configuration>
     <executions>
         <execution>
-            <phase>validate</phase>
+            <phase>validate</phase> <!-- default -->
             <goals>
                 <goal>format</goal>
             </goals>

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -3,6 +3,7 @@ package org.antipathy.mvn_scalafmt;
 import org.antipathy.mvn_scalafmt.model.Summary;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -15,7 +16,7 @@ import java.util.List;
 /**
  * Get the location of the config file and pass to Formatter
  */
-@Mojo(name = "format")
+@Mojo(name = "format", defaultPhase = LifecyclePhase.VALIDATE)
 public class FormatMojo extends AbstractMojo {
 
     @Parameter(property = "format.configLocation")


### PR DESCRIPTION
# Description

This change allows omitting setting `validate` phase explicitly in pom.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran locally.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
