### PR TITLE
Explicitly set the goal prefix as "scalafmt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Add the following snippet to your pom.
 Note: `version.scala.binary` refers to major releases of scala ie. 2.11, 2.12 or 2.13.  
 mvn_scalafmt_2.11 will soon be deprecated and may not receive future releases
 
+You can also invoke the plugin directly via `mvn scalafmt:format`.
+
 ## Versioning 
 
 This plugin follows the following versioning convention:

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${version.maven.plugin.plugin}</version>
+                <configuration>
+                    <goalPrefix>scalafmt</goalPrefix>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.antipathy</groupId>


### PR DESCRIPTION
# Description

Since the plugin doesn't follow the standard naming which automatically
assigns a user-friendly goal prefix, set one explicitly. Otherwise, we
can only invoke the plugin via `mvn mvn-scalafmt_2.12:format` which is
not as simple as `mvn scalafmt:format`.

https://maven.apache.org/guides/introduction/introduction-to-plugin-prefix-mapping.html

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran locally.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
