### PR TITLE
Add a parameter to validate while still writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The latest release should be visible at the top of this readme.
           <param>${project.basedir}/src/test/scala</param>
         </testSourceDirectories>
         <validateOnly>false</validateOnly> <!-- check formatting without changing files -->
+        <validate>false</validate> <!-- check formatting and change files -->
         <onlyChangedFiles>true</onlyChangedFiles> <!-- only format (staged) files that have been changed from the specified git branch -->
         <!-- The git branch to check against
              If branch.startsWith(": ") the value in <branch> tag is used as a command to run

--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -32,6 +32,8 @@ public class FormatMojo extends AbstractMojo {
     private boolean respectVersion;
     @Parameter(property = "format.validateOnly", defaultValue = "false")
     private boolean validateOnly;
+    @Parameter(property = "format.validate", defaultValue = "false")
+    private boolean validate;
     @Parameter(property = "format.onlyChangedFiles", defaultValue = "false")
     private boolean onlyChangedFiles;
     /** if branch.startsWith(": "), ex set in pom.xml:
@@ -86,7 +88,7 @@ public class FormatMojo extends AbstractMojo {
                         useSpecifiedRepositories ? getRepositoriesUrls(mavenRepositories) : new ArrayList<String>()
                 ).format(sources);
                 getLog().info(result.toString());
-                if (validateOnly && result.unformattedFiles() != 0) {
+                if ((validateOnly || validate) && result.unformattedFiles() != 0) {
                     throw new MojoExecutionException("Scalafmt: Unformatted files found");
                 }
             } catch (Exception e) {


### PR DESCRIPTION
# Description

In addition to the existing `validateOnly` flag, let's add the `validate` which allows both reformatting files and also failing the build if they hadn't been properly formatted.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran locally.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
