### PR TITLE
Mark FormatMojo as threadSafe because it is thread-safe

### DIFF
--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Get the location of the config file and pass to Formatter
  */
-@Mojo(name = "format", defaultPhase = LifecyclePhase.VALIDATE)
+@Mojo(name = "format", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public class FormatMojo extends AbstractMojo {
 
     @Parameter(property = "format.configLocation")


### PR DESCRIPTION
# Description

This will help avoid warning messages like one reported in #215 for multi-threaded maven builds

Fixes # 215

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Not tested, this is a straight forward change. A similar change exists [here](https://github.com/davidB/scala-maven-plugin/blob/master/src/main/java/scala_maven/AddSourceMojo.java#L21)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes