### PR TITLE
Improve summary logging

### DIFF
--- a/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
+++ b/src/main/java/org/antipathy/mvn_scalafmt/FormatMojo.java
@@ -86,7 +86,7 @@ public class FormatMojo extends AbstractMojo {
                         project.getBasedir(),
                         useSpecifiedRepositories ? getRepositoriesUrls(mavenRepositories) : new ArrayList<String>()
                 ).format(sources);
-                getLog().info(result.toString());
+                result.print(getLog());
                 if (validateOnly && result.unformattedFiles() != 0) {
                     throw new MojoExecutionException("Scalafmt: Unformatted files found");
                 }

--- a/src/main/scala/org/antipathy/mvn_scalafmt/model/Summary.scala
+++ b/src/main/scala/org/antipathy/mvn_scalafmt/model/Summary.scala
@@ -1,5 +1,7 @@
 package org.antipathy.mvn_scalafmt.model
 
+import org.apache.maven.plugin.logging.Log
+
 // $COVERAGE-OFF$
 
 /** Class representing the result of a run of the plugin
@@ -13,11 +15,13 @@ case class Summary(
   fileDetails: Seq[FileSummary]
 ) {
 
-  override def toString: String =
-    s"""Scalafmt results: $unformattedFiles of $totalFiles were unformatted
-       |Details:
-       |${fileDetails.mkString(System.lineSeparator)}
-     """.stripMargin
+  def print(log: Log) = {
+    log.info(s"Scalafmt results: $unformattedFiles of $totalFiles were unformatted")
+    log.info("Details:")
+    fileDetails.foreach { fileSummary =>
+      log.info("- " + fileSummary.toString)
+    }
+  }
 }
 
 // $COVERAGE-ON$


### PR DESCRIPTION
# Description

This PR improves logging for the summary.

The result becomes:

```
❯ ./mvnw scalafmt:format
[INFO] Scanning for projects...
[INFO]
[INFO] -----------------------< org.acme:scala3-maven >------------------------
[INFO] Building scala3-maven 1.0.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- scalafmt:1.1.0.SNAPSHOT:format (default-cli) @ scala3-maven ---
[INFO] parsed config (v3.8.1): /Users/cdepaula/repos/scala/scala3-maven/.scalafmt.conf
[INFO] Scalafmt results: 0 of 2 were unformatted
[INFO] Details:
[INFO] - Correctly formatted: Hello.scala
[INFO] - Correctly formatted: HelloTest.scala
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.091 s
[INFO] Finished at: 2024-04-02T11:25:08-03:00
[INFO] ------------------------------------------------------------------------
```

Fixes #337 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Integrated tests passes.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
